### PR TITLE
fix: Change frictionless version to be a range

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
     given-names: "Rodrigo Juliani"
     orcid: https://orcid.org/0000-0002-1688-6155
 title: "MicroView"
-version: 0.10.0
+version: 0.10.1
 url: "https://github.com/jvfe/microview"

--- a/microview/__init__.py
+++ b/microview/__init__.py
@@ -1,4 +1,4 @@
 name = "microview"
 __author__ = """João Vitor F. Cavalcante"""
 __email__ = "jvfe@ufrn.edu.br"
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.10.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requirements = [
     "rich",
     "rich-click",
     "click-option-group",
-    "frictionless==4.32.0",
+    "frictionless>=4.32.0, <5",
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,6 @@ setup(
         "Documentation": "https://jvfe.github.io/microview/",
         "Source Code": "https://github.com/jvfe/microview",
     },
-    version="0.10.0",
+    version="0.10.1",
     zip_safe=False,
 )


### PR DESCRIPTION
- **fix: Change frictionless versions to be a range instead**
- **Bump version: 0.10.0 → 0.10.1**
